### PR TITLE
ores: limit the amount of simultaneous requests made to ores

### DIFF
--- a/reports/OresUtils.js
+++ b/reports/OresUtils.js
@@ -27,7 +27,8 @@ module.exports = {
 	 */
 	queryRevisions: function(models, revids, errors) {
 		var oresdata = {};
-		var sets = utils.arrayChunk(revids, 50);
+		var requestsLimit = Math.floor(20 / models.length);
+		var sets = utils.arrayChunk(revids, requestsLimit);
 		return bot.seriesBatchOperation(sets, (set, i) => {
 			return bot.rawRequest({
 				method: 'get',


### PR DESCRIPTION
As part of the ORES to Lift Wing migration we are assisting users to migrate easily through a temporary service named ores-legacy which has substituted ORES. The limitation is that only 20 simultaneous requests/revids scores can be requested according to [ORES Swagger docs](https://ores.wikimedia.org/docs#/default/get_scores_v3_scores__context__get).
At the moment SDZeroBot makes 100 such requests (2 models * 50 revision ids) and this PR is an atttemp to make it comply with the limit in order to get successful responses.

@siddharthvp Let me know if this would work as I have limited JS experience.
Related task: https://phabricator.wikimedia.org/T342960
Related issue: #34 
Bug: T342960